### PR TITLE
Creación del nuevo modal para cursos (Issue #25)

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -9,6 +9,7 @@ import { providePrimeNG } from 'primeng/config';
 import { routes } from './app.routes';
 import Aura from '@primeuix/themes/aura';
 import { provideHttpClient } from '@angular/common/http';
+import { CUSTOM_PROVIDERS } from './core/providers/providers';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -17,6 +18,7 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes),
     provideHttpClient(),
     provideAnimationsAsync(),
+    ...CUSTOM_PROVIDERS,
     providePrimeNG({
       theme: {
         preset: Aura,

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -3,7 +3,6 @@ import { RouterOutlet } from '@angular/router';
 import { ButtonModule } from 'primeng/button';
 import { PrimeNG } from 'primeng/config';
 import { StyleClassModule } from 'primeng/styleclass';
-import { CUSTOM_PROVIDERS } from './core/providers/providers';
 import { ModalHostComponent } from './containers/host/app-modal-host.component';
 import { ModalService } from './containers/host/app-modal.service';
 import { AlertService } from './containers/alerts/app-alert.service';
@@ -21,7 +20,7 @@ import { MessageService } from 'primeng/api';
     ModalHostComponent,
     AlertHostComponent,
   ],
-  providers: [...CUSTOM_PROVIDERS, MessageService],
+  providers: [MessageService],
 })
 export class App implements OnInit, AfterViewInit {
   protected title = 'plataforma-admin-dicta';

--- a/src/app/containers/host/app-modal-host.component.ts
+++ b/src/app/containers/host/app-modal-host.component.ts
@@ -32,6 +32,8 @@ export class ModalHostComponent {
       Object.assign(cmpRef.instance, data);
     }
 
+    cmpRef.changeDetectorRef.detectChanges();
+
     return cmpRef;
   }
 }

--- a/src/app/containers/host/modal-registry.ts
+++ b/src/app/containers/host/modal-registry.ts
@@ -1,9 +1,10 @@
 import { Type } from '@angular/core';
 import { NuevaCategoria } from 'src/app/ui/modals/categoria/nueva-categoria.modal';
 import { UserModalComponent } from 'src/app/ui/modals/user.modal.component';
-
+import { NuevoCursoModal } from 'src/app/ui/modals/curso/nuevo-curso.modal';
 
 export const MODAL_REGISTRY: Record<string, Type<object>> = {
   user: UserModalComponent,
-  nuevaCategoria:NuevaCategoria
+  nuevaCategoria: NuevaCategoria,
+  nuevoCurso: NuevoCursoModal,
 };

--- a/src/app/core/enums/models.enum.ts
+++ b/src/app/core/enums/models.enum.ts
@@ -1,3 +1,4 @@
 export enum MODELS_ENUM {
   NUEVA_CATEGORIA = 'nuevaCategoria',
+  NUEVO_CURSO = 'nuevoCurso',
 }

--- a/src/app/core/mappers/curso.mapper.ts
+++ b/src/app/core/mappers/curso.mapper.ts
@@ -1,0 +1,66 @@
+import { FormGroup } from '@angular/forms';
+import { Curso } from '@class/cursos/Curso.class';
+import { CursoFormValue } from 'src/app/pages/cursos/cursos-form.presenter';
+
+export class CursoMapper {
+  static formToPayload(form: FormGroup): Partial<Curso> {
+    const rawValue = form.getRawValue() as CursoFormValue;
+
+    const precio = CursoMapper.toNumber(rawValue?.precio);
+    const fechaInicio = CursoMapper.toDate(rawValue?.fechaInicio);
+    const duracionSemanas = CursoMapper.toNumber(rawValue?.duracion?.cantidad);
+    const beneficios = CursoMapper.mapBeneficios(rawValue?.beneficios ?? null);
+    const imagen = (rawValue?.imagen ?? '').trim();
+
+    return {
+      nombre: rawValue?.nombre ?? '',
+      descripcion: rawValue?.descripcion ?? '',
+      categoriaId: rawValue?.categoriaId ?? '',
+      profesorId: rawValue?.profesorId ?? '',
+      beneficios,
+      imagen,
+      precio,
+      fechaInicio,
+      duracionSemanas,
+    } as Partial<Curso>;
+  }
+
+  private static mapBeneficios(
+    beneficios: string | { titulo: string; descripcion: string }[] | null
+  ): { titulo: string; descripcion: string }[] {
+    if (Array.isArray(beneficios)) {
+      return beneficios.map((beneficio) => ({
+        titulo: beneficio.titulo,
+        descripcion: beneficio.descripcion,
+      }));
+    }
+
+    if (!beneficios) {
+      return [];
+    }
+
+    return beneficios
+      .split(',')
+      .map((beneficio) => beneficio.trim())
+      .filter((beneficio) => beneficio.length)
+      .map((beneficio) => ({ titulo: beneficio, descripcion: beneficio }));
+  }
+
+  private static toNumber(value: unknown): number | null {
+    if (value === null || value === undefined || value === '') {
+      return null;
+    }
+
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? null : parsed;
+  }
+
+  private static toDate(value: unknown): Date | null {
+    if (!value) {
+      return null;
+    }
+
+    const date = value instanceof Date ? value : new Date(String(value));
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+}

--- a/src/app/core/services/cursos/curso-modal-data.service.ts
+++ b/src/app/core/services/cursos/curso-modal-data.service.ts
@@ -1,0 +1,141 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, map } from 'rxjs';
+import { Categoria } from '@class/categoria/Categoria.class';
+import { CategoriaService } from '../categorias/categoria.service';
+import { environment } from '@environments/environment';
+import { Profesor } from '@class/profesor/Profesor.class';
+
+type ProfesoresApiResponse =
+  | Profesor[]
+  | { data?: { _value?: Profesor[] } }
+  | { data?: Profesor[] }
+  | { items?: Profesor[] }
+  | null
+  | undefined;
+type UploadResponse =
+  | string
+  | {
+      data?: { _value?: string; url?: string } | string;
+      message?: string;
+    };
+
+@Injectable({ providedIn: 'root' })
+export class CursoModalDataService {
+  private readonly profesoresUrl = `${environment.URL_NEST_BACKEND}/profesores`;
+  private readonly uploadCursoUrl = `${environment.URL_NEST_BACKEND}/az-upload/upload/cursos`;
+
+  constructor(
+    private readonly categoriaService: CategoriaService,
+    private readonly http: HttpClient
+  ) {}
+
+  listarCategorias(): Observable<Categoria[]> {
+    return this.categoriaService.listarCategorias();
+  }
+
+  listarProfesores(): Observable<Profesor[]> {
+    return this.http.get<ProfesoresApiResponse>(this.profesoresUrl).pipe(
+      map((response) => this.mapProfesores(response))
+    );
+  }
+
+  subirImagenCurso(file: File): Observable<string> {
+    const formData = new FormData();
+    formData.append('file', file, file.name);
+
+    return this.http.post<UploadResponse>(this.uploadCursoUrl, formData).pipe(
+      map((response) => this.extractUploadUrl(response))
+    );
+  }
+
+  private mapProfesores(response: ProfesoresApiResponse): Profesor[] {
+    if (!response) {
+      return [];
+    }
+
+    if (Array.isArray(response)) {
+      return response.map((profesor) => new Profesor(profesor));
+    }
+
+    if (this.hasDirectData(response)) {
+      const dataArray = response.data ?? [];
+      return dataArray.map((profesor) => new Profesor(profesor));
+    }
+
+    if (this.hasWrappedData(response)) {
+      const wrapped = response.data._value ?? [];
+      return wrapped.map((profesor) => new Profesor(profesor));
+    }
+
+    if (this.hasItems(response)) {
+      return response.items.map((profesor) => new Profesor(profesor));
+    }
+
+    return [];
+  }
+
+  private hasDirectData(
+    response: Exclude<ProfesoresApiResponse, null | undefined | Profesor[]>
+  ): response is { data: Profesor[] } {
+    return (
+      typeof response === 'object' &&
+      response !== null &&
+      'data' in response &&
+      Array.isArray((response as { data?: unknown }).data)
+    );
+  }
+
+  private hasWrappedData(
+    response: Exclude<ProfesoresApiResponse, null | undefined | Profesor[]>
+  ): response is { data: { _value?: Profesor[] } } {
+    if (typeof response !== 'object' || response === null || !('data' in response)) {
+      return false;
+    }
+
+    const data = (response as { data?: { _value?: unknown } }).data;
+    return !!data && Array.isArray(data._value);
+  }
+
+  private hasItems(
+    response: Exclude<ProfesoresApiResponse, null | undefined | Profesor[]>
+  ): response is { items: Profesor[] } {
+    return (
+      typeof response === 'object' &&
+      response !== null &&
+      'items' in response &&
+      Array.isArray((response as { items?: unknown }).items)
+    );
+  }
+
+  private extractUploadUrl(response: UploadResponse): string {
+    const candidate =
+      typeof response === 'object' && response !== null
+        ? (response as { data?: unknown }).data ?? response
+        : response;
+
+    if (typeof candidate === 'string') {
+      return candidate;
+    }
+
+    if (
+      candidate &&
+      typeof candidate === 'object' &&
+      '_value' in candidate &&
+      typeof (candidate as { _value?: unknown })._value === 'string'
+    ) {
+      return (candidate as { _value: string })._value;
+    }
+
+    if (
+      candidate &&
+      typeof candidate === 'object' &&
+      'url' in candidate &&
+      typeof (candidate as { url?: unknown }).url === 'string'
+    ) {
+      return (candidate as { url: string }).url;
+    }
+
+    throw new Error('No se pudo obtener la URL de la imagen subida');
+  }
+}

--- a/src/app/pages/cursos/cursos-form.presenter.ts
+++ b/src/app/pages/cursos/cursos-form.presenter.ts
@@ -1,0 +1,107 @@
+import { Injectable } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { StepPresenter } from 'src/app/core/helpers/step.presenter';
+
+interface DuracionForm {
+  cantidad: FormControl<number | string | null>;
+  unidad: FormControl<string | null>;
+}
+
+export interface CursoFormValue {
+  nombre: string | null;
+  descripcion: string | null;
+  categoriaId: string | null;
+  beneficios: string | null;
+  imagen: string | null;
+  precio: number | string | null;
+  fechaInicio: string | null;
+  profesorId: string | null;
+  duracion: {
+    cantidad: number | string | null;
+    unidad: string | null;
+  };
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CursosFormPresenter extends StepPresenter<CursoFormValue> {
+  nombre!: FormControl<string | null>;
+  descripcion!: FormControl<string | null>;
+  categoriaId!: FormControl<string | null>;
+  beneficios!: FormControl<string | null>;
+  imagen!: FormControl<string | null>;
+  precio!: FormControl<number | string | null>;
+  fechaInicio!: FormControl<string | null>;
+  profesorId!: FormControl<string | null>;
+  duracion!: FormGroup<DuracionForm>;
+
+  constructor(private readonly fb: FormBuilder) {
+    super();
+    this.createForm();
+  }
+
+  private createControls(): void {
+    this.nombre = this.fb.control<string | null>(null, [
+      Validators.required,
+      Validators.minLength(3),
+    ]);
+
+    this.descripcion = this.fb.control<string | null>(null, [
+      Validators.required,
+      Validators.maxLength(500),
+    ]);
+
+    this.categoriaId = this.fb.control<string | null>(null, [Validators.required]);
+    this.beneficios = this.fb.control<string | null>(null);
+    this.imagen = this.fb.control<string | null>(null, [Validators.maxLength(250)]);
+
+    this.precio = this.fb.control<number | string | null>(null, [
+      Validators.required,
+      Validators.min(0),
+    ]);
+
+    this.fechaInicio = this.fb.control<string | null>(null, [Validators.required]);
+    this.profesorId = this.fb.control<string | null>(null, [Validators.required]);
+
+    this.duracion = this.fb.group({
+      cantidad: this.fb.control<number | string | null>(1, [
+        Validators.required,
+        Validators.min(1),
+      ]),
+      unidad: this.fb.control<string | null>('Semana', [Validators.required]),
+    });
+  }
+
+  private createForm(): void {
+    this.createControls();
+    this.form = this.fb.group({
+      nombre: this.nombre,
+      descripcion: this.descripcion,
+      categoriaId: this.categoriaId,
+      beneficios: this.beneficios,
+      imagen: this.imagen,
+      precio: this.precio,
+      fechaInicio: this.fechaInicio,
+      profesorId: this.profesorId,
+      duracion: this.duracion,
+    });
+  }
+
+  reset(): void {
+    this.form.reset({
+      nombre: null,
+      descripcion: null,
+      categoriaId: null,
+      beneficios: null,
+      imagen: null,
+      precio: null,
+      fechaInicio: null,
+      profesorId: null,
+      duracion: {
+        cantidad: 1,
+        unidad: 'Semana',
+      },
+    });
+  }
+}

--- a/src/app/pages/cursos/cursos.css
+++ b/src/app/pages/cursos/cursos.css
@@ -6,6 +6,13 @@
   flex-wrap: wrap;
 }
 
+.cursos-header__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
 .cursos-header__button {
   align-self: flex-start;
 }

--- a/src/app/pages/cursos/cursos.html
+++ b/src/app/pages/cursos/cursos.html
@@ -4,13 +4,25 @@
       <h2 class="m-0 text-900 text-3xl font-bold">Cursos</h2>
       <p class="m-0 text-600">Listado general de cursos registrados en la plataforma.</p>
     </div>
-    <button
-      type="button"
-      pButton
-      class="p-button-outlined p-button-secondary cursos-header__button"
-      label="Actualizar"
-      (click)="refrescar()"
-    ></button>
+    <div class="cursos-header__actions">
+      <button
+        type="button"
+        pButton
+        severity="primary"
+        size="small"
+        class="cursos-header__button"
+        label="Nuevo Curso +"
+        (click)="abrirModalNuevoCurso()"
+      ></button>
+      <button
+        type="button"
+        pButton
+        class="p-button-outlined p-button-secondary cursos-header__button"
+        size="small"
+        label="Actualizar"
+        (click)="refrescar()"
+      ></button>
+    </div>
   </header>
 
   <section class="cursos-filtros">
@@ -82,7 +94,7 @@
             <div class="curso-card__beneficios" *ngIf="curso.beneficios.length; else sinBeneficios">
               <h4 class="curso-card__beneficios-title">Beneficios</h4>
               <ul class="curso-card__beneficios-list">
-                @for (beneficio of curso.beneficios; track beneficio.titulo) {
+                @for (beneficio of curso.beneficios; track $index) {
                   <li class="curso-card__beneficio-item">
                     <strong>{{ beneficio.titulo }}</strong>
                     <span>{{ beneficio.descripcion }}</span>

--- a/src/app/patterns/facade/curso.facade.ts
+++ b/src/app/patterns/facade/curso.facade.ts
@@ -21,6 +21,18 @@ export class CursoFacade {
       });
   }
 
+  crearCurso(payload: Partial<Curso>): Observable<Curso> {
+    return this.cursoService.crearCurso(payload).pipe(
+      tap((cursoCreado) => {
+        const cursosActualizados = [
+          new Curso(cursoCreado),
+          ...this.cursos$.value,
+        ];
+        this.cursos$.next(cursosActualizados);
+      })
+    );
+  }
+
   actualizarCurso(id: string, payload: Partial<Curso>): Observable<Curso> {
     return this.cursoService.actualizarCurso(id, payload).pipe(
       tap((cursoActualizado) => {

--- a/src/app/shared/components/sidebar/sidebar.html
+++ b/src/app/shared/components/sidebar/sidebar.html
@@ -65,8 +65,10 @@
           </a>
           <div class="mt-2 text-gray-200 font-medium text-sm">Landing</div>
         </li>
-        <li class="w-6 text-center mt-3" routerLink="/cursos">
+        <li class="w-6 text-center mt-3">
           <a
+            routerLink="/cursos"
+            routerLinkActive="active"
             pRipple
             class="cursor-pointer inline-flex align-items-center justify-content-center border-2 border-gray-500 hover:bg-gray-700 active:bg-gray-400 text-gray-200 hover:text-gray-100 transition-colors transition-duration-150"
             style="width: 60px; height: 60px; border-radius: 10px"

--- a/src/app/ui/modals/curso/nuevo-curso.modal.css
+++ b/src/app/ui/modals/curso/nuevo-curso.modal.css
@@ -1,0 +1,109 @@
+.curso-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.curso-form__row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.curso-form__field {
+  flex: 1 1 200px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.curso-form__field--tight-top {
+  margin-top: -0.7rem;
+}
+
+.curso-form__field label {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.curso-form__field input,
+.curso-form__field select,
+.curso-form__field textarea {
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  padding: 0.55rem 0.75rem;
+  font-size: 0.95rem;
+}
+
+.curso-form__duration {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.curso-form__duration input,
+.curso-form__duration select {
+  flex: 1;
+}
+
+.curso-form__image-controls {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.curso-form__file-input {
+  display: none;
+}
+
+.curso-form__file-button {
+  border: 1px dashed #6c63ff;
+  background-color: #f5f3ff;
+  color: #4338ca;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.curso-form__file-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.curso-form__image-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 0.35rem;
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+.curso-form__image-remove {
+  border: none;
+  background: transparent;
+  color: #dc2626;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.curso-form__image-preview {
+  margin-top: 0.5rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.curso-form__image-preview img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  display: block;
+}
+
+.curso-form__error {
+  color: #dc2626;
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+}

--- a/src/app/ui/modals/curso/nuevo-curso.modal.html
+++ b/src/app/ui/modals/curso/nuevo-curso.modal.html
@@ -1,0 +1,166 @@
+<p-dialog
+  header="Crear Nuevo Curso"
+  [(visible)]="visible"
+  [modal]="true"
+  appendTo="body"
+  [style]="{ width: '50vw', maxWidth: '640px' }"
+  [breakpoints]="{ '960px': '80vw', '640px': '95vw' }"
+  [draggable]="false"
+  [resizable]="false"
+  (onHide)="cerrarModal()"
+>
+  <form [formGroup]="cursosFormPresenter.Form" class="curso-form">
+    <div class="curso-form__row">
+      <div class="curso-form__field">
+        <label for="nombre">Nombre del curso</label>
+        <input
+          id="nombre"
+          type="text"
+          formControlName="nombre"
+          placeholder="Ingresa el nombre"
+        />
+      </div>
+
+      <div class="curso-form__field">
+        <label for="categoria">Categoría</label>
+        <select id="categoria" formControlName="categoriaId">
+          <option value="" disabled>Selecciona una categoría</option>
+          <option *ngFor="let categoria of categorias" [value]="categoria.id">
+            {{ categoria.nombre }}
+          </option>
+        </select>
+      </div>
+    </div>
+
+    <div class="curso-form__field">
+      <label for="descripcion">Descripción</label>
+      <textarea
+        id="descripcion"
+        rows="3"
+        formControlName="descripcion"
+        placeholder="Describe brevemente el curso"
+      ></textarea>
+    </div>
+
+    <div class="curso-form__field curso-form__field--tight-top">
+      <label for="beneficios">Beneficios (separados por coma)</label>
+      <textarea
+        id="beneficios"
+        rows="2"
+        formControlName="beneficios"
+        placeholder="Incluye los beneficios principales"
+      ></textarea>
+    </div>
+
+    <div class="curso-form__field">
+      <label for="imagen">Imagen del curso</label>
+      <div class="curso-form__image-controls">
+        <input
+          id="imagen"
+          type="url"
+          formControlName="imagen"
+          placeholder="URL (opcional)"
+          (input)="onImageUrlInput()"
+        />
+        <input
+          #imagenFileInput
+          type="file"
+          accept="image/*"
+          class="curso-form__file-input"
+          (change)="onImageSelected($event)"
+        />
+        <button
+          type="button"
+          class="curso-form__file-button"
+          (click)="abrirSelectorImagen()"
+          [disabled]="isUploadingImage"
+        >
+          {{ isUploadingImage ? 'Subiendo...' : 'Elegir imagen' }}
+        </button>
+      </div>
+
+      <div class="curso-form__image-meta">
+        <span *ngIf="selectedImageName">{{ selectedImageName }}</span>
+        <button
+          type="button"
+          class="curso-form__image-remove"
+          *ngIf="imagePreviewUrl && !isUploadingImage"
+          (click)="quitarImagen()"
+        >
+          Quitar imagen
+        </button>
+      </div>
+
+      <div
+        class="curso-form__image-preview"
+        *ngIf="imagePreviewUrl && isImageFromUpload"
+      >
+        <img [src]="imagePreviewUrl" alt="Vista previa imagen del curso" />
+      </div>
+
+      <small class="curso-form__error" *ngIf="uploadError">
+        {{ uploadError }}
+      </small>
+    </div>
+
+    <div class="curso-form__row">
+      <div class="curso-form__field">
+        <label for="fechaInicio">Inicio</label>
+        <input id="fechaInicio" type="date" formControlName="fechaInicio" />
+      </div>
+
+      <div class="curso-form__field">
+        <label for="profesor">Profesor</label>
+        <select id="profesor" formControlName="profesorId">
+          <option value="" disabled>Selecciona un profesor</option>
+          <option *ngFor="let profesor of profesores" [value]="profesor.id">
+            {{ profesor.nombre }} {{ profesor.apellido }}
+          </option>
+        </select>
+      </div>
+    </div>
+
+    <div class="curso-form__row">
+      <div class="curso-form__field">
+        <label for="precio">Precio</label>
+        <input
+          id="precio"
+          type="number"
+          formControlName="precio"
+          min="0"
+          placeholder="0"
+        />
+      </div>
+
+      <div class="curso-form__field" formGroupName="duracion">
+        <label>Duración</label>
+        <div class="curso-form__duration">
+          <input type="number" formControlName="cantidad" min="1" />
+          <select formControlName="unidad">
+            <option *ngFor="let unidad of unidadesDuracion" [value]="unidad">
+              {{ unidad }}
+            </option>
+          </select>
+        </div>
+      </div>
+    </div>
+  </form>
+
+  <ng-template pTemplate="footer">
+    <p-button
+      label="Cancelar"
+      icon="pi pi-times"
+      iconPos="right"
+      styleClass="p-button-text"
+      (onClick)="cerrarModal()"
+    ></p-button>
+    <p-button
+      label="Guardar Curso"
+      icon="pi pi-check"
+      iconPos="right"
+      (onClick)="guardarCurso()"
+      [disabled]="cursosFormPresenter.Invalid || isSaving || isUploadingImage"
+      [loading]="isSaving"
+    ></p-button>
+  </ng-template>
+</p-dialog>

--- a/src/app/ui/modals/curso/nuevo-curso.modal.ts
+++ b/src/app/ui/modals/curso/nuevo-curso.modal.ts
@@ -1,0 +1,260 @@
+import { CommonModule } from '@angular/common';
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  OnDestroy,
+  OnInit,
+  Output,
+  ViewChild,
+} from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MessageService } from 'primeng/api';
+import { DialogModule } from 'primeng/dialog';
+import { ButtonModule } from 'primeng/button';
+import { finalize, take } from 'rxjs';
+
+import { ModalService } from 'src/app/containers/host/app-modal.service';
+import { CursoFacade } from 'src/app/patterns/facade/curso.facade';
+import { CursosFormPresenter } from 'src/app/pages/cursos/cursos-form.presenter';
+import { CursoMapper } from 'src/app/core/mappers/curso.mapper';
+import { CursoModalDataService } from 'src/app/core/services/cursos/curso-modal-data.service';
+import { Categoria } from '@class/categoria/Categoria.class';
+import { Profesor } from '@class/profesor/Profesor.class';
+
+@Component({
+  selector: 'app-nuevo-curso-modal',
+  templateUrl: './nuevo-curso.modal.html',
+  styleUrls: ['./nuevo-curso.modal.css'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    DialogModule,
+    ButtonModule,
+  ],
+  providers: [MessageService, CursoFacade, CursosFormPresenter],
+})
+export class NuevoCursoModal implements OnInit, OnDestroy {
+  @Output() closed = new EventEmitter<void>();
+  @Output() saved = new EventEmitter<void>();
+  @ViewChild('imagenFileInput') imagenFileInput?: ElementRef<HTMLInputElement>;
+  visible = true;
+
+  readonly unidadesDuracion: string[] = ['Día', 'Semana', 'Mes'];
+  categorias: Categoria[] = [];
+  profesores: Profesor[] = [];
+  isSaving = false;
+  isUploadingImage = false;
+  selectedImageName = '';
+  imagePreviewUrl: string | null = null;
+  uploadError: string | null = null;
+
+  private readonly maxImageSize = 5 * 1024 * 1024;
+  private previewObjectUrl: string | null = null;
+  isImageFromUpload = false;
+  private readonly defaultImageUrl =
+    'https://dictacolombia.com/wp-content/uploads/2022/10/logo-yellow.webp';
+
+  constructor(
+    private readonly modalService: ModalService,
+    private readonly cursoFacade: CursoFacade,
+    public readonly cursosFormPresenter: CursosFormPresenter,
+    private readonly modalDataService: CursoModalDataService,
+    private readonly messageService: MessageService
+  ) {}
+
+  ngOnInit(): void {
+    this.cargarCategorias();
+    this.cargarProfesores();
+  }
+
+  ngOnDestroy(): void {
+    this.resetImagenState();
+  }
+
+  guardarCurso(): void {
+    if (this.cursosFormPresenter.Invalid) {
+      this.cursosFormPresenter.MarkAllAsTouched();
+      return;
+    }
+
+    const imagenControl = this.cursosFormPresenter.Form.get('imagen');
+    const trimmedImagen = (imagenControl?.value ?? '').trim();
+    const imagenValue = trimmedImagen || this.defaultImageUrl;
+    imagenControl?.setValue(imagenValue, { emitEvent: false });
+
+    const payload = CursoMapper.formToPayload(this.cursosFormPresenter.Form);
+
+    this.isSaving = true;
+    this.cursoFacade
+      .crearCurso(payload)
+      .pipe(
+        take(1),
+        finalize(() => (this.isSaving = false))
+      )
+      .subscribe({
+        next: () => {
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Éxito',
+            detail: 'Curso creado correctamente',
+          });
+          this.saved.emit();
+          this.cursoFacade.listarCursos();
+          this.cerrarModal();
+        },
+        error: (error) => {
+          const detail =
+            (error?.error && (error.error.message || error.error.detail)) ||
+            'No se pudo crear el curso. Revisa la consola para más detalles.';
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Error',
+            detail,
+          });
+          console.error('Error al crear curso:', error);
+        },
+      });
+  }
+
+  cerrarModal(): void {
+    this.visible = false;
+    this.closed.emit();
+    this.modalService.close();
+    this.cursosFormPresenter.reset();
+    this.resetImagenState();
+  }
+
+  private cargarCategorias(): void {
+    this.modalDataService
+      .listarCategorias()
+      .pipe(take(1))
+      .subscribe({
+        next: (categorias) => (this.categorias = categorias),
+        error: () => (this.categorias = []),
+      });
+  }
+
+  private cargarProfesores(): void {
+    this.modalDataService
+      .listarProfesores()
+      .pipe(take(1))
+      .subscribe({
+        next: (profesores) => (this.profesores = profesores),
+        error: () => (this.profesores = []),
+      });
+  }
+
+  abrirSelectorImagen(): void {
+    this.imagenFileInput?.nativeElement.click();
+  }
+
+  onImageSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input?.files?.[0];
+
+    if (!file) {
+      return;
+    }
+
+    if (!file.type.startsWith('image/')) {
+      this.uploadError = 'Selecciona un archivo de imagen válido.';
+      input.value = '';
+      return;
+    }
+
+    if (file.size > this.maxImageSize) {
+      this.uploadError = 'La imagen debe pesar menos de 5 MB.';
+      input.value = '';
+      return;
+    }
+
+    this.uploadError = null;
+    this.isImageFromUpload = true;
+    this.selectedImageName = file.name;
+    this.setPreviewFromFile(file);
+
+    this.isUploadingImage = true;
+    this.modalDataService
+      .subirImagenCurso(file)
+      .pipe(
+        take(1),
+        finalize(() => {
+          this.isUploadingImage = false;
+          if (this.imagenFileInput?.nativeElement) {
+            this.imagenFileInput.nativeElement.value = '';
+          }
+        })
+      )
+      .subscribe({
+        next: (url) => {
+          this.cursosFormPresenter.Form.patchValue({ imagen: url }, { emitEvent: false });
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Imagen subida',
+            detail: 'La imagen se cargó correctamente.',
+          });
+        },
+        error: (error) => {
+          this.uploadError =
+            error?.error?.message ??
+            'No se pudo subir la imagen. Intenta nuevamente.';
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Error al subir imagen',
+            detail: this.uploadError ?? 'No se pudo subir la imagen.',
+          });
+          this.resetImagenState({ keepError: true });
+        },
+      });
+  }
+
+  onImageUrlInput(): void {
+    const value = (this.cursosFormPresenter.Form.get('imagen')?.value ?? '').trim();
+    this.cursosFormPresenter.Form.patchValue({ imagen: value || null }, { emitEvent: false });
+    this.isImageFromUpload = false;
+
+    if (value) {
+      this.selectedImageName = 'URL personalizada';
+      this.uploadError = null;
+    } else {
+      this.selectedImageName = '';
+    }
+
+    this.clearPreviewObjectUrl();
+    this.imagePreviewUrl = null;
+  }
+
+  quitarImagen(): void {
+    this.cursosFormPresenter.Form.patchValue({ imagen: null }, { emitEvent: false });
+    this.resetImagenState();
+  }
+
+  private setPreviewFromFile(file: File): void {
+    this.clearPreviewObjectUrl();
+    this.previewObjectUrl = URL.createObjectURL(file);
+    this.imagePreviewUrl = this.previewObjectUrl;
+  }
+
+  private clearPreviewObjectUrl(): void {
+    if (this.previewObjectUrl) {
+      URL.revokeObjectURL(this.previewObjectUrl);
+      this.previewObjectUrl = null;
+    }
+  }
+
+  private resetImagenState(options?: { keepError?: boolean }): void {
+    this.clearPreviewObjectUrl();
+    this.selectedImageName = '';
+    this.imagePreviewUrl = null;
+    if (!options?.keepError) {
+      this.uploadError = null;
+    }
+    this.isImageFromUpload = false;
+    this.isUploadingImage = false;
+    if (this.imagenFileInput?.nativeElement) {
+      this.imagenFileInput.nativeElement.value = '';
+    }
+  }
+}


### PR DESCRIPTION
Actualiza el modal de creación de cursos en el apartado administrativo.
Issue relacionada: Issue #25

Cambios principales:

- Se crea el formulario reactivo standalone con PrimeNG, manejando toasts y eventos saved/closed, enlazándolo al ModalService y refrescando la lista de cursos después de guardar.
- Se configura el flujo de datos del modal mediante un presenter con validaciones, un mapper para construir el payload y un servicio que obtiene categorías/profesores y gestiona la subida opcional de imágenes al endpoint az-upload.
- Se mejora la experiencia de imagen y la UI incorporando selector de archivo con preview, imagen por defecto (fallback), mensajes de error controlados y ajustes de espaciado/estilos para mantener el formulario limpio.