### PR TITLE
bug: Inicializar el form de galaxias como true en galaxias múltiples (Issue #60)

### DIFF
--- a/src/app/core/mappers/galaxia.mapper.ts
+++ b/src/app/core/mappers/galaxia.mapper.ts
@@ -36,7 +36,10 @@ export class GalaxiaMapper {
   static formToCreateDto(form: FormGroup): CreateGalaxiaDto {
     const galaxiasArray = form.get('galaxias') as FormArray;
 
-    const group = galaxiasArray.at(0) as FormGroup;
-    return this.mapGalaxiaGroupToDto(group);
+    if (!galaxiasArray || galaxiasArray.length === 0) {
+      throw new Error('No hay galaxias en el formulario');
+    }
+
+    return this.mapGalaxiaGroupToDto(galaxiasArray.at(0) as FormGroup);
   }
 }

--- a/src/app/pages/galaxias/galaxias-form.presenter.ts
+++ b/src/app/pages/galaxias/galaxias-form.presenter.ts
@@ -21,7 +21,7 @@ export class GalaxiasFormPresenter extends StepPresenter<Galaxia> {
   public createForm(): void {
     this.form = this.fb.group({
       
-      multiple: [false],
+      multiple: [true],
       nombreComun: [''],
       galaxias:this.fb.array([])
 

--- a/src/app/patterns/facade/galaxia.facade.ts
+++ b/src/app/patterns/facade/galaxia.facade.ts
@@ -28,7 +28,7 @@ export class GalaxiaFacade {
   guardarMultiplesGalaxias(data:CreateMultipleGalaxiasDto){
     this.galaxiaService
       .guardarMultiplesGalaxias(data)
-      .subscribe();
+      .subscribe(() => this.listarGalaxias());
   }
 
   obtenerGalaxia(id: string) {

--- a/src/app/ui/modals/galaxia/nueva-galaxia.modal.html
+++ b/src/app/ui/modals/galaxia/nueva-galaxia.modal.html
@@ -80,35 +80,38 @@
 
             <div formArrayName="galaxias">
 
-              <p-tabs value="0">
+              @if (galaxias.length === categorias.length) {
 
-                <p-tablist>
-                  <div class="flex align-items-center gap-3">
+                <p-tabs value="0">
+
+                  <p-tablist>
+                    <div class="flex align-items-center gap-3">
+                      @for (categoria of categorias; track categoria.id; let i = $index) {
+                        <p-tab [value]="i.toString()">
+                          {{ categoria.nombre }}
+                        </p-tab>
+                      }
+                    </div>
+                  </p-tablist>
+
+                  <p-tabpanels>
+
                     @for (categoria of categorias; track categoria.id; let i = $index) {
-                      <p-tab [value]="i.toString()">
-                        {{ categoria.nombre }}
-                      </p-tab>
+
+                      <p-tabpanel [value]="i.toString()">
+
+                        <div [formGroupName]="i" class="grid formgrid p-fluid">
+
+                          <ng-container
+                            *ngTemplateOutlet="camposInternos; context: { group: getGalaxia(i) }">
+                          </ng-container>
+
+                        </div>
+                      </p-tabpanel>
                     }
-                  </div>
-                </p-tablist>
-
-                <p-tabpanels>
-
-                  @for (categoria of categorias; track categoria.id; let i = $index) {
-
-                    <p-tabpanel [value]="i.toString()">
-
-                      <div [formGroupName]="i" class="grid formgrid p-fluid">
-
-                        <ng-container
-                          *ngTemplateOutlet="camposInternos; context: { group: galaxias.at(i) }">
-                        </ng-container>
-
-                      </div>
-                    </p-tabpanel>
-                  }
-                </p-tabpanels>
-              </p-tabs>
+                  </p-tabpanels>
+                </p-tabs>
+              }
             </div>
           </div>
         </div>

--- a/src/app/ui/modals/galaxia/nueva-galaxia.modal.ts
+++ b/src/app/ui/modals/galaxia/nueva-galaxia.modal.ts
@@ -74,6 +74,9 @@ export class NuevaGalaxia implements OnInit {
       if (res.length) {
         this.activeTab = res[0].id.toString();
       }
+      if (this.multiple) {
+        this.galaxiaFormPresenter.activarMultiples(res);
+      }
     });
 
     this.galaxiaFormPresenter.Form.get('multiple')?.valueChanges.subscribe(m => {
@@ -101,7 +104,7 @@ export class NuevaGalaxia implements OnInit {
   }
 
   getGalaxia(index: number) {
-    return this.galaxiaFormPresenter.getGalaxia(index);
+    return this.galaxias.at(index) as FormGroup;
   }
 
   guardarGalaxia() {    
@@ -144,7 +147,7 @@ export class NuevaGalaxia implements OnInit {
   }
 
   onMultipleChange(value: boolean) {
-    if (value) {
+    if (value && this.categorias.length) {
       this.galaxiaFormPresenter.activarMultiples(this.categorias);
       this.activeTab = this.categorias[0]?.id?.toString() ?? '';
     } else {


### PR DESCRIPTION
Issue relacionada: #60 

Cambios:

- Se cambió el estado del form a true en galaxias múltiples en form-presenter.
- Se corrigieron errores en el mapper de galaxias que no permitían que las tabs del form se carguen correctamente al inicializar como galaxias múltiples.
- 
Se corrigió un error de listado en el facade.
- Se editaron los html y ts del modal de nueva galaxia para que carguen correctamente al ser inicializado como form para galaxias múltiples.