### PR TITLE
feat: agregar botón eliminar cursos con modal de confirmación #52

### DIFF
--- a/src/app/containers/host/modal-registry.ts
+++ b/src/app/containers/host/modal-registry.ts
@@ -6,6 +6,7 @@ import { NuevaGalaxia } from 'src/app/ui/modals/galaxia/nueva-galaxia.modal';
 import { NuevoPlaneta } from 'src/app/ui/modals/planeta/nuevo-planeta.modal';
 import { NuevaLanding } from 'src/app/ui/modals/landing/nueva-landing.modal';
 import { EditarGalaxia } from 'src/app/ui/modals/galaxia/editar-galaxia.modal';
+import { EliminarCurso } from 'src/app/ui/modals/curso/eliminar-curso.modal';
 
 
 export const MODAL_REGISTRY: Record<string, Type<object>> = {
@@ -16,4 +17,5 @@ export const MODAL_REGISTRY: Record<string, Type<object>> = {
   nuevoPlaneta: NuevoPlaneta,
   nuevaGalaxia: NuevaGalaxia,
   editarGalaxia: EditarGalaxia,
+  eliminarCurso: EliminarCurso,
 };

--- a/src/app/core/enums/models.enum.ts
+++ b/src/app/core/enums/models.enum.ts
@@ -5,4 +5,5 @@ export enum MODELS_ENUM {
   NUEVO_PLANETA = 'nuevoPlaneta',
   NUEVA_GALAXIA = 'nuevaGalaxia',
   EDITAR_GALAXIA = 'editarGalaxia',
+  ELIMINAR_CURSO = 'eliminarCurso'
 }

--- a/src/app/pages/cursos/cursos.html
+++ b/src/app/pages/cursos/cursos.html
@@ -128,6 +128,16 @@
                 (click)="editarCurso(curso)"
                 [attr.aria-label]="'Editar curso ' + (curso.nombre || curso.id)"
               ></button>
+
+              <button
+                type="button"
+                pButton
+                class="curso-card__eliminar-btn p-button-rounded p-button-text p-button-danger"
+                icon="pi pi-trash"
+                (click)="eliminarCurso(curso)"
+                [attr.aria-label]="'Eliminar curso ' + (curso.nombre || curso.id)"
+              ></button>
+              
               <div class="curso-card__estado">
                 <label class="curso-card__estado-toggle">
                   <input

--- a/src/app/pages/cursos/cursos.ts
+++ b/src/app/pages/cursos/cursos.ts
@@ -9,6 +9,11 @@ import { Curso } from '@class/cursos/Curso.class';
 import { CursoFacade } from 'src/app/patterns/facade/curso.facade';
 import { CursoService } from 'src/app/core/services/cursos/curso.service';
 
+import { ModalService } from 'src/app/containers/host/app-modal.service';
+import { MODELS_ENUM } from 'src/app/core/enums/models.enum';
+
+import { EliminarCurso } from 'src/app/ui/modals/curso/eliminar-curso.modal';
+
 interface FilterOption {
   label: string;
   value: string;
@@ -45,7 +50,11 @@ export class Cursos implements OnInit, OnDestroy {
     maximumFractionDigits: 0,
   });
 
-  constructor(private readonly cursoFacade: CursoFacade) {
+  constructor(
+  private readonly cursoFacade: CursoFacade,
+  private readonly modalService: ModalService,
+  ) 
+  {
     this.cursos$ = this.cursoFacade.cursos$;
 
     this.categoriasOptions$ = this.cursos$.pipe(
@@ -62,10 +71,12 @@ export class Cursos implements OnInit, OnDestroy {
         if (unique.has('')) {
           options.push({ label: 'Sin categoria', value: EMPTY_CATEGORY_VALUE });
         }
+        
 
         return options;
       })
     );
+    
 
     this.precioRango$ = this.cursos$.pipe(
       map((cursos) => {
@@ -144,6 +155,12 @@ export class Cursos implements OnInit, OnDestroy {
     console.log('Editar curso', curso);
   }
 
+  eliminarCurso(curso: Curso): void {
+    const ref = this.modalService.openByName(MODELS_ENUM.ELIMINAR_CURSO, { curso });
+    (ref.instance as EliminarCurso).eliminado.subscribe(() => {
+      this.cursoFacade.listarCursos();
+    });
+  }
   onCategoriaFilterChange(value: string): void {
     this.selectedCategoria = value;
     this.categoriaFiltro$.next(value);

--- a/src/app/patterns/facade/curso.facade.ts
+++ b/src/app/patterns/facade/curso.facade.ts
@@ -31,6 +31,15 @@ export class CursoFacade {
       })
     );
   }
+  
+  eliminarCurso(id: string): Observable<Curso> {
+    return this.cursoService.eliminarCurso(id).pipe(
+      tap(() => {
+        const cursos = this.cursos$.value.filter((c) => c.id !== id);
+        this.cursos$.next(cursos);
+      })
+    );
+  }
 
   actualizarEstado(id: string, estado: boolean): Observable<Curso> {
     return this.cursoService.eliminarCurso(id).pipe(

--- a/src/app/ui/modals/curso/eliminar-curso.modal.html
+++ b/src/app/ui/modals/curso/eliminar-curso.modal.html
@@ -1,0 +1,44 @@
+<p-dialog
+  [(visible)]="visible"
+  appendTo="body"
+  [modal]="true"
+  [breakpoints]="{ '960px': '75vw', '640px': '90vw' }"
+  [style]="{ width: '30vw' }"
+  [draggable]="false"
+  [resizable]="false">
+
+  <ng-template pTemplate="header">
+    <div class="flex flex-column gap-1">
+      <h1 class="m-0 text-900 font-semibold text-xl">Eliminar curso</h1>
+      <span class="text-600 text-sm">Esta acción no se puede deshacer</span>
+    </div>
+  </ng-template>
+
+  <div class="flex align-items-center gap-3 pt-3 px-4">
+    <i class="pi pi-exclamation-triangle text-4xl text-orange-500"></i>
+    <p class="m-0 text-900">
+      ¿Estás seguro de que deseas eliminar el curso
+      <strong>{{ curso.nombre || curso.id }}</strong>?
+    </p>
+  </div>
+
+  <ng-template pTemplate="footer">
+    <div class="flex justify-content-end gap-2">
+      <p-button
+        label="Cancelar"
+        icon="pi pi-times"
+        iconPos="right"
+        variant="outlined"
+        class="text-gray-600"
+        (onClick)="close()"
+      />
+      <p-button
+        label="Eliminar"
+        icon="pi pi-trash"
+        iconPos="right"
+        severity="danger"
+        (onClick)="confirmar()"
+      />
+    </div>
+  </ng-template>
+</p-dialog>

--- a/src/app/ui/modals/curso/eliminar-curso.modal.ts
+++ b/src/app/ui/modals/curso/eliminar-curso.modal.ts
@@ -1,0 +1,43 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DialogModule } from 'primeng/dialog';
+import { ButtonModule } from 'primeng/button';
+import { take } from 'rxjs/operators';
+import { Curso } from '@class/cursos/Curso.class';
+import { CursoFacade } from 'src/app/patterns/facade/curso.facade';
+import { ModalService } from 'src/app/containers/host/app-modal.service';
+import { CURSO_PROVIDERS } from 'src/app/core/providers/curso.provider';
+import { CursoService } from 'src/app/core/services/cursos/curso.service';
+
+
+@Component({
+  selector: 'app-eliminar-curso',
+  standalone: true,
+  imports: [CommonModule, DialogModule, ButtonModule],
+  providers: [CursoFacade, CursoService, ...CURSO_PROVIDERS],
+  templateUrl: './eliminar-curso.modal.html',
+})
+
+export class EliminarCurso {
+  @Input() curso: Curso = new Curso();
+  @Output() eliminado = new EventEmitter<void>();
+  visible = true;
+
+  constructor(
+    private readonly modalService: ModalService,
+    private readonly cursoFacade: CursoFacade,
+  ) {}
+
+  confirmar(): void {
+    this.cursoFacade.eliminarCurso(this.curso.id).pipe(take(1)).subscribe(() => {
+      this.eliminado.emit();
+      this.close();
+    });
+  }
+
+  close(): void {
+    this.visible = false;
+    this.modalService.close();
+  }
+  
+}


### PR DESCRIPTION
Issue relacionada: #52

Cambios principales:
- Se agregó botón eliminar en la sección de acciones de cada curso
- Se implementó modal de confirmación antes de eliminar
- Se ejecuta petición DELETE al endpoint correspondiente
- Se actualiza la lista de cursos después de eliminar el registro