### PR TITLE
feat: Corrección para guardar galaxias individuales (Issue #42)

### DIFF
--- a/src/app/core/mappers/galaxia-multiple.mapper.ts
+++ b/src/app/core/mappers/galaxia-multiple.mapper.ts
@@ -14,7 +14,7 @@ export class GalaxiaMultipleMapper {
       textura: value.textura,
       estado: value.estado,
       tema: value.tema,
-      categoriaId: value.categoriaId,
+      categoriaId: value.categoria.id,
 
       color: value.color,
       posicion: {

--- a/src/app/core/mappers/galaxia.mapper.ts
+++ b/src/app/core/mappers/galaxia.mapper.ts
@@ -14,10 +14,7 @@ export class GalaxiaMapper {
       textura: value.textura,      
       estado: value.estado,  
       tema: value.tema,    
-      categoriaId: typeof value.categoria === 'object'
-        ? value.categoria.id
-        : value.categoria,     
-      
+      categoriaId: value.categoria.id,
       color: value.color,
       posicion: {
         x: Number(value.posicion?.x ?? 0),

--- a/src/app/pages/galaxias/galaxias-form.presenter.ts
+++ b/src/app/pages/galaxias/galaxias-form.presenter.ts
@@ -39,7 +39,6 @@ export class GalaxiasFormPresenter extends StepPresenter<Galaxia> {
       estado: [true],
       color: ['#989898', Validators.required],
       categoria: ['', Validators.required],
-      categoriaId: ['', Validators.required],
       tema: [''],
       url: [''],
       textura: [''],
@@ -97,8 +96,8 @@ export class GalaxiasFormPresenter extends StepPresenter<Galaxia> {
       const group = this.createGalaxiaGroup();
       
       group.patchValue({
-        categoriaId: String(cat.id),
-        categoria: cat.nombre ?? null,
+        categoria: cat,
+        categoriaId: cat.id
       });
 
       group.get('nombre')?.clearValidators();

--- a/src/app/ui/modals/galaxia/nueva-galaxia.modal.ts
+++ b/src/app/ui/modals/galaxia/nueva-galaxia.modal.ts
@@ -25,6 +25,7 @@ import { Divider } from 'primeng/divider';
 import { ColorPicker} from 'primeng/colorpicker';
 import { FormGroup } from '@angular/forms';
 import { SelectModule } from 'primeng/select';
+import { FormArray } from '@angular/forms';
 
 @Component({
   selector: 'app-nueva-galaxia',
@@ -44,7 +45,7 @@ import { SelectModule } from 'primeng/select';
     FieldsetModule,
     Divider,
     ColorPicker,
-    SelectModule
+    SelectModule,
   ],
   providers: [CUSTOM_GALAXIA_PROVIDER,GalaxiaService, GalaxiaFacade, CategoriaService],  
   templateUrl: './nueva-galaxia.modal.html',


### PR DESCRIPTION
Issue relacionada: #42 

Cambios:

- Se corrigió categoríaId en los mappers para que lleguen al elemento de forma correcta.
- Se corrigió la forma de declarar categoríaId en el form presenter.


Nota: 
Para su funcionamiento completo falta eliminar categoría del create-galaxia.dto.ts de backend correspondiente.

<img width="1004" height="467" alt="image" src="https://github.com/user-attachments/assets/9781faec-485e-419c-957d-bb44abb83a8b" />
