### PR TITLE
feat: eliminar filtro de color en modales de galaxias #63

### DIFF
--- a/src/app/pages/galaxias/galaxias-form.presenter.ts
+++ b/src/app/pages/galaxias/galaxias-form.presenter.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { FormBuilder, FormGroup, FormArray, Validators } from '@angular/forms';
 import { Galaxia } from '@class/galaxias/Galaxia.class';
-import { LocalStateService } from '@class/state/local-state.class';
 import { StepPresenter } from 'src/app/core/helpers/forms/step.presenter';
 import { Categoria } from '@class/categoria/Categoria.class';
 
@@ -13,7 +12,6 @@ export class GalaxiasFormPresenter extends StepPresenter<Galaxia> {
 
   constructor(
     private readonly fb: FormBuilder,
-    private readonly localStateService: LocalStateService,
   ) {
     super();
   }
@@ -35,7 +33,6 @@ export class GalaxiasFormPresenter extends StepPresenter<Galaxia> {
       descripcion: ['', Validators.required],
       imagen: ['', Validators.required],
       estado: [true],
-      color: ['#989898', Validators.required],
       categoria: ['', Validators.required],
       categoriaId: ['', Validators.required],
       tema: [''],
@@ -55,19 +52,6 @@ export class GalaxiasFormPresenter extends StepPresenter<Galaxia> {
       }),
     });
 
-    const colorControl = group.get('color');
-
-    colorControl?.valueChanges.subscribe((value) => {
-      if (!value) return;
-
-      const upper = value.toUpperCase();
-
-      if (value !== upper) {
-        colorControl.setValue(upper, { emitEvent: false });
-      }
-
-      colorControl.updateValueAndValidity({ emitEvent: false });
-    });
 
     return group;
   }

--- a/src/app/ui/modals/galaxia/editar-galaxia.modal.html
+++ b/src/app/ui/modals/galaxia/editar-galaxia.modal.html
@@ -110,29 +110,6 @@
       </p-floatLabel>
     </div>
 
-    <div class="field mb-3 col-12 md:col-6">
-      <p-floatLabel>
-        <div class="color-input-wrapper">
-          <input
-            pInputText
-            [value]="group.get('color')?.value"
-            (input)="onHexInput($event, group)"
-            class="w-full pr-8"/>
-          <p-colorpicker
-            formControlName="color"
-            format="hex"
-            appendTo="body"
-            [style]="{
-              position: 'absolute',
-              right: '0.5rem',
-              top: '50%',
-              transform: 'translateY(-50%)'
-            }">
-          </p-colorpicker>
-        </div>
-        <label>Color</label>
-      </p-floatLabel>
-    </div>
 
     <div class="field col-12 md:col-6">
       <p-floatLabel>

--- a/src/app/ui/modals/galaxia/editar-galaxia.modal.ts
+++ b/src/app/ui/modals/galaxia/editar-galaxia.modal.ts
@@ -18,7 +18,6 @@ import { CUSTOM_GALAXIA_PROVIDER } from 'src/app/core/providers/galaxia.provider
 import { CategoriaService } from 'src/app/core/services/categorias/categoria.service';
 import { Categoria } from '@class/categoria/Categoria.class';
 import { Divider } from 'primeng/divider';
-import { ColorPicker } from 'primeng/colorpicker';
 import { SelectModule } from 'primeng/select';
 import { IGalaxiaDto } from '@interfaces/galaxias/Igalaxia.dto';
 
@@ -37,7 +36,6 @@ import { IGalaxiaDto } from '@interfaces/galaxias/Igalaxia.dto';
     FloatLabelModule,
     FieldsetModule,
     Divider,
-    ColorPicker,
     SelectModule,
   ],
   providers: [CUSTOM_GALAXIA_PROVIDER, GalaxiaService, GalaxiaFacade, CategoriaService],
@@ -73,7 +71,6 @@ export class EditarGalaxia implements OnInit {
         textura: this.galaxia.textura,
         estado: this.galaxia.estado,
         tema: this.galaxia.tema,
-        color: this.galaxia.color,
         categoriaId: this.galaxia.categoriaId,
         categoria: categoriaSeleccionada ?? null,
         posicion: this.galaxia.posicion,
@@ -105,11 +102,5 @@ export class EditarGalaxia implements OnInit {
   close(): void {
     this.visible = false;
     this.modalService.close();
-  }
-
-  onHexInput(event: Event, group: FormGroup): void {
-    const value = (event.target as HTMLInputElement).value?.toUpperCase();
-    if (!value) return;
-    group.get('color')?.setValue(value);
   }
 }

--- a/src/app/ui/modals/galaxia/nueva-galaxia.modal.html
+++ b/src/app/ui/modals/galaxia/nueva-galaxia.modal.html
@@ -172,31 +172,6 @@
       </p-floatLabel>
     </div>
 
-    <div class="field mb-3 col-12 md:col-6">
-      <p-floatLabel>
-        <div class="color-input-wrapper">
-          <input
-            pInputText            
-            [value]="group.get('color')?.value"
-            (input)="onHexInput($event, group)"
-            class="w-full pr-8"/>
-
-          <p-colorpicker
-            formControlName="color"
-            format="hex"
-            appendTo="body"        
-            [style]="{
-              position: 'absolute',
-              right: '0.5rem',
-              top: '50%',
-              transform: 'translateY(-50%)'
-            }">
-          </p-colorpicker>
-        </div>
-        <label>Color</label>
-      </p-floatLabel>      
-    </div>
-
     <div class="field col-12 md:col-6">
       <p-floatLabel>
         <input pInputText formControlName="imagen" class="w-full"/>

--- a/src/app/ui/modals/galaxia/nueva-galaxia.modal.ts
+++ b/src/app/ui/modals/galaxia/nueva-galaxia.modal.ts
@@ -22,7 +22,6 @@ import { IGalaxiaDto } from '@interfaces/galaxias/Igalaxia.dto';
 import { CategoriaService } from 'src/app/core/services/categorias/categoria.service';
 import { Categoria } from '@class/categoria/Categoria.class';
 import { Divider } from 'primeng/divider';
-import { ColorPicker} from 'primeng/colorpicker';
 import { FormGroup } from '@angular/forms';
 import { SelectModule } from 'primeng/select';
 
@@ -43,7 +42,6 @@ import { SelectModule } from 'primeng/select';
     TabsModule,
     FieldsetModule,
     Divider,
-    ColorPicker,
     SelectModule
   ],
   providers: [CUSTOM_GALAXIA_PROVIDER,GalaxiaService, GalaxiaFacade, CategoriaService],  
@@ -154,13 +152,5 @@ export class NuevaGalaxia implements OnInit {
       this.galaxiaFormPresenter.activarSimple();
       this.activeTab = '';
     }
-  }
-
-  onHexInput(event: Event, group: FormGroup) {
-    const value = (event.target as HTMLInputElement).value?.toUpperCase();
-
-    if (!value) return;
-
-    group.get('color')?.setValue(value);
   }
 }


### PR DESCRIPTION
Issue relacionada: #63

Cambios principales:
- Se eliminó el campo de color (p-colorpicker e input hex) del modal de nueva galaxia
- Se eliminó el campo de color (p-colorpicker e input hex) del modal de editar galaxia
- Se eliminó el método onHexInput y el import de ColorPicker en ambos modales
- Se eliminó el campo color y su lógica de validación en el form presenter

Notita: Al guardar cambios en editar galaxia, el backend responde 400 Bad Request porque el campo color ahora se envía vacío. El backend requiere un valor en ese campo. Se sugiere hacerlo opcional en el backend.