### PR TITLE
feat: corregir funcionamiento del boton eliminar landing page #49

### DIFF
--- a/src/app/containers/layout/app.layout.component.ts
+++ b/src/app/containers/layout/app.layout.component.ts
@@ -13,6 +13,7 @@ import { FileUploadModule } from 'primeng/fileupload';
 import { MultiSelectModule } from 'primeng/multiselect';
 import { TagModule } from 'primeng/tag';
 
+
 @Component({
   selector: 'app-layout',
   templateUrl: './app.layout.component.html',

--- a/src/app/infraestructure/landing.repository.impl.ts
+++ b/src/app/infraestructure/landing.repository.impl.ts
@@ -60,7 +60,6 @@ export class LandingRepositoryImpl implements LandingRepository {
 
     return this.http
       .delete<{ data: CreateLandingDto }>(direccion)
-      .pipe(map((response) => Landing.fromJson(response.data)));
-  } 
-
+      .pipe(map((response) => response.data ? Landing.fromJson(response.data) : new Landing()));
+  }
 }


### PR DESCRIPTION
Issue relacionada: #49

Cambios principales:
- Se implementó el método eliminarLandingService() en LandingRepositoryImpl con llamada DELETE al endpoint /landing-page/{id}
- Se conectó eliminarLanding() en LandingFacade con manejo de error
- El botón eliminar muestra confirmación antes de ejecutar
- La lista se actualiza automáticamente después de eliminar