### PR TITLE
fix: validacion visual de nombre duplicado al registrar planetas #87

### DIFF
--- a/src/app/patterns/facade/planetas.facade.ts
+++ b/src/app/patterns/facade/planetas.facade.ts
@@ -10,6 +10,7 @@ import { CreatePlanetaDto, CreateMultiplesPlanetaDto } from '@interfaces/interfa
 export class PlanetaFacade {
   planetas$ = new BehaviorSubject<Planeta[]>([]);
   planeta$ = new BehaviorSubject<Planeta>(new Planeta());
+  planetaError$ = new BehaviorSubject<string | null>(null);
 
   constructor(private readonly planetaService: PlanetaService) {}
 
@@ -20,12 +21,17 @@ export class PlanetaFacade {
   }
 
   guardarPlaneta(dto: CreatePlanetaDto) {
+    this.planetaError$.next(null);
     this.planetaService.guardarPlaneta(dto).subscribe({
       next: (resp) => {
         this.planeta$.next(resp);
         this.listarPlanetas();
       },
-      error: (err) => console.error('Error guardando planeta', err),
+      error: (err) => {
+        const mensaje = err?.error?.message ?? '';
+        const esDuplicado = err?.status === 400 && mensaje.toLowerCase().includes('ya está en uso');
+        this.planetaError$.next(esDuplicado ? 'El nombre del planeta ya existe' : mensaje || 'Error al guardar el planeta');
+      },
     });
   }
   

--- a/src/app/ui/modals/planeta/nuevo-planeta.modal.html
+++ b/src/app/ui/modals/planeta/nuevo-planeta.modal.html
@@ -247,11 +247,15 @@
 <form class="flex flex-column gap-4 mt-4" [formGroup]="formSimple">
   <div class="grid formgrid p-fluid row-gap-3">
     <div class="field col-12 md:col-6">
-      <p-floatLabel>
-        <input pInputText formControlName="nombre" class="w-full" />
-        <label>Nombre del planeta</label>
-      </p-floatLabel>
-    </div>
+          <p-floatLabel>
+            <input pInputText formControlName="nombre" class="w-full" />
+            <label>Nombre del planeta</label>
+          </p-floatLabel>
+          @if (formSimple.get('nombre')?.hasError('nombreDuplicado')) {
+            <small class="p-error">{{ mensajeErrorNombre }}</small>
+          }
+        </div>
+        
     <div class="field col-12 md:col-6">
       <p-floatLabel>
         <input pInputText formControlName="codigo" class="w-full" [readonly]="true" style="background-color: var(--p-inputtext-disabled-background)" />

--- a/src/app/ui/modals/planeta/nuevo-planeta.modal.ts
+++ b/src/app/ui/modals/planeta/nuevo-planeta.modal.ts
@@ -73,6 +73,7 @@ export class NuevoPlaneta implements OnInit {
   mostrarSelectorPlaneta = false;
   planetasCreados: Planeta[] = [];
   planetaElegido: Planeta | null = null;
+  mensajeErrorNombre: string | null = null;
 
   grupos = [
     { title: 'Niños', value: 'NIÑOS' },
@@ -279,8 +280,16 @@ export class NuevoPlaneta implements OnInit {
       beneficios: val.beneficios ?? [],
     };
 
+    this.mensajeErrorNombre = null;
     this.planetaFacade.planeta$.next(new Planeta());
     this.planetaFacade.guardarPlaneta(dto as unknown as CreatePlanetaDto);
+    this.planetaFacade.planetaError$.pipe(
+      filter((error) => error !== null),
+      take(1)
+    ).subscribe((error) => {
+      this.mensajeErrorNombre = error;
+      this.formSimple.get('nombre')?.setErrors({ nombreDuplicado: true });
+    });
     this.planetaFacade.planeta$.pipe(
       filter((p) => !!p.id),
       take(1)


### PR DESCRIPTION
Se implementó captura y manejo del error de nombre duplicado al crear un planeta desde el formulario simple.

- Se agregó un observable de error en PlanetaFacade para propagar la respuesta del backend cuando el nombre ya existe
- El formulario ya no se cierra automáticamente al recibir un error del backend
- Se muestra un mensaje visible junto al campo Nombre del planeta indicando el conflicto
- El campo Nombre del planeta se resalta en rojo cuando existe el conflicto
- Se mantienen todos los datos ingresados en el formulario, permitiendo corregir el nombre y reintentar sin perder información
- No se recarga la página ni se cierra el modal al producirse el error