### PR TITLE
feat: botones para eliminar peligros y beneficios al crear planeta #88

### DIFF
--- a/src/app/pages/planetas/planetas-form.presenter.ts
+++ b/src/app/pages/planetas/planetas-form.presenter.ts
@@ -100,6 +100,13 @@ export class PlanetaFormPresenter extends StepPresenter<Planeta> {
   public addBeneficio(index: number): void {
     this.getBeneficios(index).push(this.crearBeneficio());
   }
+  public removePeligro(planetaIndex: number, peligroIndex: number): void {
+    this.getPeligros(planetaIndex).removeAt(peligroIndex);
+  }
+
+  public removeBeneficio(planetaIndex: number, beneficioIndex: number): void {
+    this.getBeneficios(planetaIndex).removeAt(beneficioIndex);
+  }
 
   private listenNombreChanges(): void {
     this.form.get('nombre')?.valueChanges.subscribe(nombre => {

--- a/src/app/ui/modals/planeta/nuevo-planeta.modal.html
+++ b/src/app/ui/modals/planeta/nuevo-planeta.modal.html
@@ -158,7 +158,7 @@
                           </div>
                         </p-tabpanel>
 
-                        <p-tabpanel value="peligros">
+                            <p-tabpanel value="peligros">
                           <button pButton type="button" label="Agregar peligro" class="mb-3" (click)="planetaFormPresenter.addPeligro(i)"></button>
                           <div formArrayName="peligros">
                             @for (peligro of getPeligros(i).controls; track peligro; let j = $index) {
@@ -200,13 +200,16 @@
                                       <label>Descripción</label>
                                     </p-floatLabel>
                                   </div>
+                                  <div class="col-12 flex justify-content-end">
+                                    <button pButton type="button" label="Eliminar peligro" severity="danger" (click)="planetaFormPresenter.removePeligro(i, j)"></button>
+                                  </div>
                                 </div>
                               </p-fieldset>
                             }
                           </div>
                         </p-tabpanel>
 
-                        <p-tabpanel value="beneficios">
+                          <p-tabpanel value="beneficios">
                           <button pButton type="button" label="Agregar beneficio" class="mb-3" (click)="planetaFormPresenter.addBeneficio(i)"></button>
                           <div formArrayName="beneficios">
                             @for (beneficio of getBeneficios(i).controls; track beneficio; let j = $index) {
@@ -223,6 +226,9 @@
                                       <textarea pTextarea formControlName="descripcion" rows="5" class="w-full"></textarea>
                                       <label>Descripción</label>
                                     </p-floatLabel>
+                                  </div>
+                                  <div class="col-12 flex justify-content-end">
+                                    <button pButton type="button" label="Eliminar beneficio" severity="danger" (click)="planetaFormPresenter.removeBeneficio(i, j)"></button>
                                   </div>
                                 </div>
                               </p-fieldset>


### PR DESCRIPTION
Se agregaron botones para eliminar peligros y beneficios durante la creación de un planeta en el formulario múltiple.

- Se agregaron los métodos removePeligro() y removeBeneficio() en PlanetaFormPresenter
- Se agregó el botón "Eliminar peligro" en cada peligro del formulario múltiple
- Se agregó el botón "Eliminar beneficio" en cada beneficio del formulario múltiple
- La eliminación es dinámica, sin recargar la página, y la lista se reordena automáticamente
- Se mantiene la información del resto del formulario al eliminar un elemento
- Se validó que el planeta se registra correctamente en el backend con la lista actualizada de peligros y beneficios