### PR TITLE
fix: corregir selector de cantidad de registros en listado de planetas #94

### DIFF
--- a/src/app/infraestructure/categoria.repository.impl.ts
+++ b/src/app/infraestructure/categoria.repository.impl.ts
@@ -19,16 +19,17 @@ export class CategoriaRepositoryImpl implements CategoriaRepository {
 
   listarCategoriasService(): Observable<Categoria[]> {
     const direccion = `${this.apiUrl}/categorias`;
+    const params = { limit: '1000', page: '1' };
 
     return this.http
-      .get<IGenericArrays<Categoria[]>>(direccion)
+      .get<IGenericArrays<Categoria[]>>(direccion, { params })
       .pipe(
         map((response: IGenericArrays<Categoria[]>) =>
           response.data._value.map((categoria) => Categoria.fromJson(categoria))
         )
       );
   }
-
+    
   obtenerCategoriaService(categoriaId: string): Observable<Categoria> {
     const direccion = `${this.apiUrl}/categorias`;
 

--- a/src/app/infraestructure/galaxia.repository.impl.ts
+++ b/src/app/infraestructure/galaxia.repository.impl.ts
@@ -19,15 +19,16 @@ export class GalaxiaRepositoryImpl implements GalaxiaRepository {
 
   listarGalaxiasService(): Observable<Galaxia[]> {
     const direccion = `${this.apiUrl}/galaxias`;   
+    const params = { limit: '1000', page: '1' };
 
     return this.http
-      .get<{data:IGalaxiaDto[]}>(direccion)
+      .get<{data:IGalaxiaDto[]}>(direccion, { params })
       .pipe(
         map((response) =>
           response.data.map((dto: IGalaxiaDto) => Galaxia.fromJson(dto))
         )
       );
-  } 
+  }
 
   obtenerGalaxiaService(galaxiaId: string): Observable<Galaxia> {
     const direccion = `${this.apiUrl}/galaxias`;


### PR DESCRIPTION

El selector de cantidad de registros (10/25/50) en el listado de Planetas no funcionaba: siempre mostraba solo 10 resultados, porque el backend aplica ese límite por defecto cuando el frontend no le especifica `limit` y `page`.

--Solución
Se ajustó `PlanetaRepositoryImpl.listarPlanetasService()` para pedir explícitamente `limit=1000`, trayendo todos los planetas de una vez. Así la paginación de PrimeNG funciona bien en el cliente según la opción elegida.

Por consistencia, se aplicó el mismo ajuste en Galaxias y Categorías, que tenían el mismo riesgo.

--Verificado
- Selector en 10, 25 y 50 muestra la cantidad correcta
- Si hay menos registros que el valor seleccionado, se muestran todos
- Confirmado también contra el backend vía Swagger


